### PR TITLE
Phpunit fix

### DIFF
--- a/src/ApplicationIdentifiers.php
+++ b/src/ApplicationIdentifiers.php
@@ -24,7 +24,9 @@ class ApplicationIdentifiers
         Identifiers\SellByDateIdentifier::class,                 // 16
         Identifiers\ExpirationDateIdentifier::class,             // 17
         Identifiers\VariantIdentifier::class,                    // 20
-        Identifiers\SerialNumberIdentifier::class,               // 21
+	Identifiers\SerialNumberIdentifier::class,               // 21
+	Identifiers\ConsumerVariantIdentifier::class,            // 22
+	Identifiers\VariableCountIdentifier::class,              // 30
         Identifiers\CompanyInternalInformationIdentifier::class, // 91
 
         Identifiers\OriginIdentifier::class,                     // 422

--- a/src/Identifiers/ConsumerVariantIdentifier.php
+++ b/src/Identifiers/ConsumerVariantIdentifier.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace NGT\Barcode\GS1Decoder\Identifiers;
+
+use NGT\Barcode\GS1Decoder\Identifiers\Abstracts\Identifier;
+
+class ConsumerVariantIdentifier extends Identifier
+{
+    /**
+     * @inheritDoc
+     */
+    public function getTitle(): string
+    {
+        return 'CONSUMER VARIANT';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getName(): string
+    {
+        return 'Consumer product variant';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCode(): string
+    {
+        return '22';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLength(): int
+    {
+        return 20;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormat(): string
+    {
+        return $this->standardFormat('1,20');
+    }
+}
+

--- a/src/Identifiers/ConsumerVariantIdentifier.php
+++ b/src/Identifiers/ConsumerVariantIdentifier.php
@@ -3,9 +3,10 @@ declare(strict_types=1);
 
 namespace NGT\Barcode\GS1Decoder\Identifiers;
 
+use NGT\Barcode\GS1Decoder\Contracts\Identifiers\VariableLength;
 use NGT\Barcode\GS1Decoder\Identifiers\Abstracts\Identifier;
 
-class ConsumerVariantIdentifier extends Identifier
+class ConsumerVariantIdentifier extends Identifier implements VariableLength
 {
     /**
      * @inheritDoc

--- a/src/Identifiers/VariableCountIdentifier.php
+++ b/src/Identifiers/VariableCountIdentifier.php
@@ -21,7 +21,7 @@ class VariableCountIdentifier extends Identifier implements VariableLength
      */
     public function getName(): string
     {
-        return 'Quantity or Units';
+        return 'Variable count of items';
     }
 
     /**
@@ -45,7 +45,7 @@ class VariableCountIdentifier extends Identifier implements VariableLength
      */
     public function getFormat(): string
     {
-        return $this->standardFormat('1,8');
+        return '/^\d{1,8}$/';
     }
 }
 

--- a/src/Identifiers/VariableCountIdentifier.php
+++ b/src/Identifiers/VariableCountIdentifier.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace NGT\Barcode\GS1Decoder\Identifiers;
+
+use NGT\Barcode\GS1Decoder\Contracts\Identifiers\VariableLength;
+use NGT\Barcode\GS1Decoder\Identifiers\Abstracts\Identifier;
+
+class VariableCountIdentifier extends Identifier implements VariableLength
+{
+    /**
+     * @inheritDoc
+     */
+    public function getTitle(): string
+    {
+        return 'VAR. COUNT';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getName(): string
+    {
+        return 'Quantity or Units';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCode(): string
+    {
+        return '30';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLength(): int
+    {
+        return 8;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormat(): string
+    {
+        return $this->standardFormat('1,8');
+    }
+}
+

--- a/tests/Integration/DecodeTest.php
+++ b/tests/Integration/DecodeTest.php
@@ -120,7 +120,17 @@ class DecodeTest extends TestCase
                 '01006141410073491714123110A12345B[FNC1]211234ABC[FNC1]',
                 '21',
                 '1234ABC',
-            ],
+	    ],
+	    'Consumer product variant' => [
+		'01006141410073491714123110A12345B[FNC1]22ABC1234[FNC1]',
+		'22',
+		'ABC1234'
+	    ],
+	    'Variable count of items [Numeric]' => [
+		'01006141410073491714123110A12345B[FNC1]300100[FNC1]',
+		'30',
+		'0100'
+	    ],
             'Company internal information' => [
                 '01087106420356209135[FNC1]',
                 '91',


### PR DESCRIPTION
Previously added two identifiers;

- ConsumerVariantIdentifier (N2+X..20)
- VariableCountIdentifier (N2+N..8)
- Added unit tests

Last commit was to correct ConsumerVariantIdentifier, which omitted implementing the VariableLength class, causing the unit test to fail.